### PR TITLE
Enforce 4-6 digit ticket IDs in PR title regex

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   title-regex:
     description: "Regex to ensure PR title matches. Allows anything by default."
     required: false
-    default: ^[Aa][Nn]-(?!0+[:\/])\d+[:\/].*
+    default: ^[Aa][Nn]-(?!0+[:\/])\d{4,6}[:\/].*
   on-failed-regex-create-review:
     description:
       "Whether the action should create a PR review & comment when the regex
@@ -19,7 +19,7 @@ inputs:
       "Comment for the bot to post on PRs that fail the regex. Use %regex% to
       reference regex."
     required: false
-    default: "PR name does not conform with convention 😵‍💫 (PR title must start with 'AN-' followed by non-zero numbers, deliminated by a ':' or '/')"
+    default: "PR name does not conform with convention 😵‍💫 (PR title must start with 'AN-' followed by a 4-6 digit non-zero ticket number, deliminated by a ':' or '/')"
   on-failed-regex-fail-action:
     description: "Whether the action should fail when the regex doesn't match."
     required: false


### PR DESCRIPTION
## Summary
- Tightens the default `title-regex` in `action.yml` from `\d+` to `\d{4,6}` so ticket IDs must be 4–6 digits.
- Keeps the existing all-zeros guard via negative lookahead, now ensuring titles like `AN-0000:foo`, `AN-00000:foo`, `AN-000000:foo` are rejected alongside `AN-000:foo`.
- Updates the failure comment to mention the 4–6 digit, non-zero requirement.

No `dist/` rebuild needed — the action reads the regex via `getInput("title-regex")` at runtime (see `src/main.ts:8`).

## Test plan
- [ ] Verify `AN-1234:foo`, `AN-12345/foo`, `AN-123456:foo` pass.
- [ ] Verify `AN-000:foo`, `AN-0000:foo`, `AN-00000:foo`, `AN-000000:foo` fail.
- [ ] Verify `AN-12:foo` (too short) and `AN-1234567:foo` (too long) fail.
- [ ] Verify `AN-1234` (missing `:`/`/` delimiter) still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)